### PR TITLE
Feat toolbar font

### DIFF
--- a/extras/docs/configuartion.md
+++ b/extras/docs/configuartion.md
@@ -33,6 +33,7 @@ The config property is a JSON object.
         ["paragraph", "blockquote", "removeBlockquote", "horizontalLine", "orderedList", "unorderedList"],
         ["link", "unlink", "image"],
         ["code"]
-    ]
+    ],
+    "toolbarFontSize": "0.8rem"
 }
 ```

--- a/extras/docs/toolbar.md
+++ b/extras/docs/toolbar.md
@@ -28,3 +28,7 @@ Toolbar is provided with the editor configuration as
 ```
 
 Providing empty toolbar array will enable all default buttons
+
+## Font size
+The toolbar font size can be configured via the config object passed to ngx-editor.
+Use standard CSS font size values.

--- a/src/app/ngx-editor/common/ngx-editor.defaults.ts
+++ b/src/app/ngx-editor/common/ngx-editor.defaults.ts
@@ -21,7 +21,8 @@ export const ngxEditorConfig = {
         ['paragraph', 'blockquote', 'removeBlockquote', 'horizontalLine', 'orderedList', 'unorderedList'],
         ['link', 'unlink', 'image'],
         ['code']
-    ]
+    ],
+    toolbarFontSize: '0.8rem'
 };
 
 /**

--- a/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.html
+++ b/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.html
@@ -1,4 +1,4 @@
-<div class="ngx-toolbar" *ngIf="config['showToolbar']">
+<div class="ngx-toolbar" *ngIf="config['showToolbar']" [style.font-size]="config['toolbarFontSize']">
   <div class="ngx-toolbar-set">
     <button type="button" class="ngx-editor-button" *ngIf="canEnableToolbarOptions('bold')" (click)="triggerCommand('bold')"
       title="Bold" [disabled]="!config['enableToolbar']">

--- a/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.scss
+++ b/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.scss
@@ -4,7 +4,6 @@
 
 .ngx-toolbar {
     background-color: #f5f5f5;
-    font-size: 0.8rem;
     padding: 0.2rem;
     border: 1px solid #ddd;
 


### PR DESCRIPTION
Feature toolbar font size

# I'm submitting a...

- [ ] Bug Fix
- [x] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)

### Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [x] Docs have been added / updated (for bug fixes / features)

Added new default for toolbar font size to the default config object. Name of default is toolbarFontSize.

Use
Nothing is required to utilize the default font size for the toolbar. If a different font size is desired, pass in a config object to ngx-editor with the toolbarFontSize field set to a legal CSS value for font-size.

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Does this PR affects any existing issues?

- [ ] Yes
- [x] No

