### PR TITLE
feat: customise image size and alt text on insert

### DIFF
--- a/src/app/ngx-editor/common/services/command-executor.service.ts
+++ b/src/app/ngx-editor/common/services/command-executor.service.ts
@@ -41,17 +41,21 @@ export class CommandExecutorService {
   /**
    * inserts image in the editor
    *
-   * @param imageURI url of the image to be inserted
+   * @param image url, alt, width and height of the image to be inserted
    */
-  insertImage(imageURI: string): void {
+  insertImage(image: { url: string, alt: string, width: number | null, height: number | null }): void {
     if (this.savedSelection) {
-      if (imageURI) {
+      if (image.url) {
         const restored = Utils.restoreSelection(this.savedSelection);
         if (restored) {
-          const inserted = document.execCommand('insertImage', false, imageURI);
-          if (!inserted) {
+          try {
+            // Validate URL
+            const url = new URL(image.url);
+          } catch (e) {
             throw new Error('Invalid URL');
           }
+          const imageTag = `<img alt="${image.alt}" width="${image.width}" height="${image.height}" src="${image.url}" />`;
+          this.insertHtml(imageTag);
         }
       }
     } else {

--- a/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.html
+++ b/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.html
@@ -196,8 +196,21 @@
         <form class="extra-gt" [formGroup]="imageForm" (ngSubmit)="imageForm.valid && insertImage()" autocomplete="off">
           <div class="form-group">
             <label for="imageURLInput" class="small">URL</label>
-            <input type="text" class="form-control-sm" id="imageURLInput" placeholder="URL" formControlName="imageUrl"
+            <input type="url" class="form-control-sm" id="imageURLInput" placeholder="URL" formControlName="imageUrl"
               required>
+          </div>
+          <div class="form-group">
+            <label for="imageAltTextInput" class="small">Alternate text</label>
+            <input type="url" class="form-control-sm" id="imageAltTextInput" placeholder="Alternate text" formControlName="imageAlt">
+          </div>
+          <div class="row form-group">
+            <div class="col">
+              <input type="text" class="form-control-sm" formControlName="height" placeholder="height (px)" pattern="[0-9]*">
+            </div>
+            <div class="col">
+              <input type="text" class="form-control-sm" formControlName="width" placeholder="width (px)" pattern="[0-9]*">
+            </div>
+            <label class="small">Height/Width</label>
           </div>
           <button type="submit" class="btn-primary btn-sm btn">Submit</button>
         </form>

--- a/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.ts
+++ b/src/app/ngx-editor/ngx-editor-toolbar/ngx-editor-toolbar.component.ts
@@ -110,12 +110,15 @@ export class NgxEditorToolbarComponent implements OnInit {
    */
   buildImageForm(): void {
     this.imageForm = this._formBuilder.group({
-      imageUrl: ['', [Validators.required]]
+      imageUrl: ['', [Validators.required]],
+      imageAlt: [''],
+      height: [''],
+      width: [''],
     });
   }
 
   /**
-   * create insert image form
+   * create video image form
    */
   buildVideoForm(): void {
     this.videoForm = this._formBuilder.group({
@@ -165,7 +168,12 @@ export class NgxEditorToolbarComponent implements OnInit {
   /** insert image in the editor */
   insertImage(): void {
     try {
-      this._commandExecutorService.insertImage(this.imageForm.value.imageUrl);
+      this._commandExecutorService.insertImage({
+        url: this.imageForm.value.imageUrl,
+        alt: this.imageForm.value.imageAlt,
+        width: this.imageForm.value.width,
+        height: this.imageForm.value.height,
+      });
     } catch (error) {
       this._messageService.sendMessage(error.message);
     }


### PR DESCRIPTION
<!-- Make sure your title is clear -->
<!-- To mark a task, use [x]. -->

# I'm submitting a...

- [ ] Bug Fix
- [x] Feature
- [ ] Other (Refactoring, Added tests, Documentation, ...)

### Checklist

- [x] Commit Messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [x] Docs have been added / updated (for bug fixes / features) (n/a)

### Description

Add width, height and alternate text for images:

![Image Insert Form](https://user-images.githubusercontent.com/59569242/99404144-8f356980-28eb-11eb-8446-58b0b38f7a7a.png)

### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

### Does this PR affects any existing issues?

- [x] Yes
- [ ] No

closes #267 


I think this should be merged in v4.2.0 or v4.1.2 instead of master.

