### PR TITLE
fix: prevent undefined variables on destroy component

### DIFF
--- a/src/lib/components/bubble/bubble.component.ts
+++ b/src/lib/components/bubble/bubble.component.ts
@@ -93,6 +93,8 @@ export class BubbleComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.updateSubscription.unsubscribe();
+    if (this.updateSubscription) {
+      this.updateSubscription.unsubscribe();
+    }
   }
 }

--- a/src/lib/editor.component.ts
+++ b/src/lib/editor.component.ts
@@ -119,6 +119,8 @@ export class NgxEditorComponent implements ControlValueAccessor, OnInit, OnChang
       subscription.unsubscribe();
     });
 
-    this.editor.destroy();
+    if (this.editor) {
+      this.editor.destroy();
+    }
   }
 }

--- a/src/lib/editor.component.ts
+++ b/src/lib/editor.component.ts
@@ -119,8 +119,6 @@ export class NgxEditorComponent implements ControlValueAccessor, OnInit, OnChang
       subscription.unsubscribe();
     });
 
-    if (this.editor) {
-      this.editor.destroy();
-    }
+    this.editor.destroy();
   }
 }

--- a/src/lib/modules/menu/menu.component.ts
+++ b/src/lib/modules/menu/menu.component.ts
@@ -111,6 +111,8 @@ export class MenuComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.updateSubscription.unsubscribe();
+    if (this.updateSubscription) {
+      this.updateSubscription.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [X] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [X] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes
When you use dynamic component instantiation appears undefined access errors on method ngDestroy

### Does this PR affects any existing issues?

- [ ] yes
- [X] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
