### PR TITLE
feat: make menu bar wrap to second line if little space is available

### DIFF
--- a/projects/ngx-editor/src/lib/editor.component.scss
+++ b/projects/ngx-editor/src/lib/editor.component.scss
@@ -95,6 +95,7 @@ $menubar-text-padding: 0 $menu-item-spacing;
 
 .NgxEditor__MenuBar {
   display: flex;
+  flex-wrap: wrap;
   padding: $menubar-padding;
   cursor: default;
   background-color: white;

--- a/projects/ngx-editor/src/lib/modules/menu/bubble/bubble.component.scss
+++ b/projects/ngx-editor/src/lib/modules/menu/bubble/bubble.component.scss
@@ -6,6 +6,7 @@
 
 :host {
   display: flex;
+  flex-wrap: wrap;
   background-color: #000;
   color: white;
   padding: 5px;


### PR DESCRIPTION
<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [x] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [x] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

<!--
  please be thorough and clearly explain the problem being solved.
-->
Enables the menu to wrap to a second row, if it runs out of space instead ob being cut of.

### Does this PR affects any existing issues?

- [x] yes
- [ ] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
closes #383 
