### PR TITLE
Fix: Export InjectionToken editor configuration

### DIFF
--- a/projects/ngx-editor/src/lib/Locals.ts
+++ b/projects/ngx-editor/src/lib/Locals.ts
@@ -1,4 +1,4 @@
-const defaults: Record<string, string> = {
+export const defaults: Record<string, string> = {
   // menu
   bold: 'Bold',
   italic: 'Italic',

--- a/projects/ngx-editor/src/lib/editor.module.ts
+++ b/projects/ngx-editor/src/lib/editor.module.ts
@@ -2,6 +2,7 @@ import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { NgxEditorConfig } from './types';
+import { defaults } from './Locals';
 
 import { NgxEditorComponent } from './editor.component';
 import { NgxEditorServiceConfig } from './editor-config.service';
@@ -12,7 +13,7 @@ import { MenuComponent } from './modules/menu/menu.component';
 import { ImageViewComponent } from './components/image-view/image-view.component';
 import { FloatingMenuComponent } from './modules/menu/floating-menu/floating-menu.component';
 
-const NGX_EDITOR_CONFIG_TOKEN = new InjectionToken<NgxEditorConfig>('NgxEditorConfig');
+export const NGX_EDITOR_CONFIG_TOKEN = new InjectionToken<NgxEditorConfig>('NgxEditorConfig');
 
 @NgModule({
   imports: [
@@ -32,13 +33,13 @@ const NGX_EDITOR_CONFIG_TOKEN = new InjectionToken<NgxEditorConfig>('NgxEditorCo
 })
 
 export class NgxEditorModule {
-  static forRoot(config: NgxEditorConfig): ModuleWithProviders<NgxEditorModule> {
+  static forRoot(config?: NgxEditorConfig): ModuleWithProviders<NgxEditorModule> {
     return {
       ngModule: NgxEditorModule,
       providers: [
         {
           provide: NGX_EDITOR_CONFIG_TOKEN,
-          useValue: config,
+          useValue: config ?? { locals: defaults },
         },
         {
           provide: NgxEditorServiceConfig,
@@ -49,13 +50,13 @@ export class NgxEditorModule {
     };
   }
 
-  static forChild(config: NgxEditorConfig): ModuleWithProviders<NgxEditorModule> {
+  static forChild(config?: NgxEditorConfig): ModuleWithProviders<NgxEditorModule> {
     return {
       ngModule: NgxEditorModule,
       providers: [
         {
           provide: NGX_EDITOR_CONFIG_TOKEN,
-          useValue: config,
+          useValue: config ?? { locals: defaults },
         },
         {
           provide: NgxEditorServiceConfig,


### PR DESCRIPTION
Export NGX_EDITOR_CONFIG_TOKEN to enable editor configuration by using a provider instead of static configuration.

This PR contains:

- [x] bugfix
- [x] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [x] no

### Checklist

- [x] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [x] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

Add the ability to provide **NGX_EDITOR_CONFIG_TOKEN** by using a provider. Just below an example when using [@ngx-translate](https://github.com/ngx-translate/core) package for internationalization :

```typescript
export function ngxEditorConfigFactory(translateService: TranslateService): NgxEditorConfig {
  return {
    locals: {
      italic: translateService.instant('styles.italic'),
      bold: translateService.instant('styles.bold'),
    },
  };
}

@NgModule({
  imports: [CommonModule, ReactiveFormsModule, NgxEditorModule.forRoot()],
  providers: [
    {
      useFactory: ngxEditorConfigFactory,
      provide: NGX_EDITOR_CONFIG_TOKEN,
      deps: [TranslateService],
    },
  ],
})
export class MyModule {}
```

### Does this PR affects any existing issues?

- [ ] yes
- [x] no
