### PR TITLE
feat: link toolbar show/hide 'Open in new tab' option

### DIFF
--- a/docs/src/content/docs/menu.md
+++ b/docs/src/content/docs/menu.md
@@ -24,6 +24,8 @@ export class AppComponent implements OnInit, OnDestroy {
     ['ordered_list', 'bullet_list'],
     [{ heading: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] }],
     ['link', 'image'],
+    // or, set options for link:
+    //[{ link: { showOpenInNewTab: false } }, 'image'],
     ['text_color', 'background_color'],
     ['align_left', 'align_center', 'align_right', 'align_justify'],
     ['horizontal_rule', 'format_clear'],

--- a/projects/ngx-editor/src/lib/modules/menu/link/link.component.html
+++ b/projects/ngx-editor/src/lib/modules/menu/link/link.component.html
@@ -32,7 +32,7 @@
       </div>
     </div>
 
-    <div class="NgxEditor__Popup--FormGroup">
+    <div class="NgxEditor__Popup--FormGroup" *ngIf="showOpenInNewTab">
       <div class="NgxEditor__Popup--Col">
         <label>
           <input type="checkbox" formControlName="openInNewTab" />

--- a/projects/ngx-editor/src/lib/modules/menu/link/link.component.ts
+++ b/projects/ngx-editor/src/lib/modules/menu/link/link.component.ts
@@ -1,6 +1,6 @@
 import {
   Component, ElementRef,
-  HostListener, OnDestroy, OnInit,
+  HostListener, Input, OnDestroy, OnInit,
 } from '@angular/core';
 import { AbstractControl, FormControl, FormGroup, Validators } from '@angular/forms';
 import { EditorView } from 'prosemirror-view';
@@ -19,6 +19,8 @@ import { nanoid } from 'nanoid';
 })
 
 export class LinkComponent implements OnInit, OnDestroy {
+  @Input() showOpenInNewTab = true;
+
   showPopup = false;
   isActive = false;
   canExecute = true;
@@ -115,10 +117,16 @@ export class LinkComponent implements OnInit, OnDestroy {
     const { dispatch, state } = this.editorView;
     const { selection } = state;
 
+    let target: string | undefined;
+
+    if (this.showOpenInNewTab) {
+      target = openInNewTab ? '_blank' : '_self';
+    }
+
     const attrs = {
       title: href,
       href,
-      target: openInNewTab ? '_blank' : '_self',
+      target,
     };
 
     if (selection.empty) {

--- a/projects/ngx-editor/src/lib/modules/menu/menu.component.html
+++ b/projects/ngx-editor/src/lib/modules/menu/menu.component.html
@@ -14,6 +14,13 @@
       <!-- link -->
       <ngx-link [class]="iconContainerClass" *ngIf="item === 'link'"></ngx-link>
 
+      <ng-container *ngIf="isLinkWithOptions(item)">
+        <ngx-link
+          [class]="iconContainerClass"
+          [showOpenInNewTab]="getLinkOptions(item).showOpenInNewTab ?? true"
+        ></ngx-link>
+      </ng-container>
+
       <!-- image -->
       <ngx-image [class]="iconContainerClass" *ngIf="item === 'image'"> </ngx-image>
 

--- a/projects/ngx-editor/src/lib/modules/menu/menu.component.ts
+++ b/projects/ngx-editor/src/lib/modules/menu/menu.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 
 import { NgxEditorError } from 'ngx-editor/utils';
-import { Toolbar, ToolbarItem, ToolbarDropdown } from '../../types';
+import { Toolbar, ToolbarItem, ToolbarDropdown, ToolbarLink, ToolbarLinkOptions } from '../../types';
 import { MenuService } from './menu.service';
 import Editor from '../../Editor';
 
@@ -130,6 +130,17 @@ export class MenuComponent implements OnInit {
 
   getDropdownItems(item: ToolbarItem): ToolbarDropdown {
     return item as ToolbarDropdown;
+  }
+
+  isLinkWithOptions(item: ToolbarItem): boolean {
+    // NOTE: it is not sufficient to check for a `link` property
+    // as String.prototype.link is a valid (although deprecated) method
+    return typeof item === 'object'
+      && typeof (item as ToolbarLink)?.link === 'object';
+  }
+
+  getLinkOptions(item: ToolbarItem): ToolbarLinkOptions {
+    return (item as ToolbarLink)?.link;
   }
 
   ngOnInit(): void {

--- a/projects/ngx-editor/src/lib/types.ts
+++ b/projects/ngx-editor/src/lib/types.ts
@@ -31,10 +31,12 @@ export type TBItems = 'bold'
 | 'format_clear';
 
 export type ToolbarDropdown = { heading?: TBHeadingItems[] };
+export type ToolbarLinkOptions = { showOpenInNewTab?: boolean };
+export type ToolbarLink = { link: ToolbarLinkOptions };
 export type ToolbarCustomMenuItem = (editorView: EditorView) => TCR;
 export type ToolbarDropdownGroupKeys = keyof ToolbarDropdown;
 export type ToolbarDropdownGroupValues = ToolbarDropdown[ToolbarDropdownGroupKeys];
-export type ToolbarItem = TBItems | ToolbarDropdown | ToolbarCustomMenuItem;
+export type ToolbarItem = TBItems | ToolbarDropdown | ToolbarLink | ToolbarCustomMenuItem;
 export type Toolbar = Array<ToolbarItem[]>;
 
 export interface NgxEditorConfig {


### PR DESCRIPTION
<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [ ] bugfix
- [X] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [X] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [X] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [X] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

This adds a new option for the Link toolbar icon/popup to disable the "Open in new tab" option from showing in the UI, for i.e. a Markdown serializer where target is not supported. Specifying `"link"` as a ToolbarItem is still supported and the default is to show the "Open in new tab" option, but you can now pass an object instead to specify its options via `{ link: { showOpenInNewTab: false } }`, similar to the `heading` toolbar item.

### Does this PR affects any existing issues?

- [ ] yes
- [X] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
