### PR TITLE
fix: wrong input type to `url`

### DIFF
--- a/projects/ngx-editor/src/lib/modules/menu/image/image.component.html
+++ b/projects/ngx-editor/src/lib/modules/menu/image/image.component.html
@@ -20,7 +20,7 @@
         <label class="NgxEditor__Popup--Label" [htmlFor]="getId('image-popup-url')">{{
           getLabel('url') | async
         }}</label>
-        <input type="href" [id]="getId('image-popup-url')" formControlName="src" autocomplete="off" />
+        <input type="url" [id]="getId('image-popup-url')" formControlName="src" autocomplete="off" />
         <div *ngIf="src.touched && src.invalid" class="NgxEditor__HelpText NgxEditor__HelpText--Error">
           {{ src.errors?.['pattern'] && getLabel('enterValidUrl') | async }}
         </div>

--- a/projects/ngx-editor/src/lib/modules/menu/link/link.component.html
+++ b/projects/ngx-editor/src/lib/modules/menu/link/link.component.html
@@ -20,7 +20,7 @@
     <div class="NgxEditor__Popup--FormGroup">
       <div class="NgxEditor__Popup--Col">
         <label class="NgxEditor__Popup--Label" [htmlFor]="getId('link-popup-url')">{{ getLabel('url') | async }}</label>
-        <input type="href" [id]="getId('link-popup-url')" formControlName="href" autocomplete="off" />
+        <input type="url" [id]="getId('link-popup-url')" formControlName="href" autocomplete="off" />
         <div *ngIf="href.touched && href.invalid" class="NgxEditor__HelpText NgxEditor__HelpText--Error">
           {{ href.errors?.['pattern'] && getLabel('enterValidUrl') | async }}
         </div>


### PR DESCRIPTION
<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [x] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [x] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

The input fields for links and images set to type `url` instead of non-existing type `href`.

### Does this PR affects any existing issues?

- [x] yes
- [ ] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
fixes: #550 
