### PR TITLE
fix: add attribute type="button" at insert-command component to prevent form submit (#564)

### DIFF
--- a/projects/ngx-editor/src/lib/modules/menu/insert-command/insert-command.component.html
+++ b/projects/ngx-editor/src/lib/modules/menu/insert-command/insert-command.component.html
@@ -1,4 +1,5 @@
 <button
+  type="button"
   class="NgxEditor__MenuItem--Icon"
   [disabled]="disabled"
   [class.NgxEditor--Disabled]="disabled"


### PR DESCRIPTION
<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [x] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [x] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

<!--
  please be thorough and clearly explain the problem being solved.
-->
When ngx-editor used inside form and user click on 'Clear Formatting' button this leads to form submit. Required to add type='button' attribute to button of insert-command component.

### Does this PR affects any existing issues?

- [x] yes
- [ ] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
fixes #564