### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   test:
     name: Karma unit tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/ngx-editor/security/code-scanning/2](https://github.com/sibiraj-s/ngx-editor/security/code-scanning/2)

The best way to fix this problem is by explicitly setting a `permissions` block in the workflow or job to limit the permissions of the `GITHUB_TOKEN`. Since the provided workflow does not seem to perform any write actions (like creating releases, modifying issues, etc.), it is safe and secure to restrict permissions to `contents: read`, which is the minimal recommended starting point. This can be done by inserting `permissions: contents: read` either at the top level (applies to all jobs) or just to the job flagged by CodeQL (in this case, line 14: the `test` job). Edit `.github/workflows/tests.yml` by adding the following line immediately after either the workflow's `name`, or under `test:` (prefer job-level unless global permissions are warranted).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
