### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test-lib:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/ngx-editor/security/code-scanning/1](https://github.com/sibiraj-s/ngx-editor/security/code-scanning/1)

To address the issue, we need to explicitly restrict the permissions of the `GITHUB_TOKEN` for the `test-lib` job. Since this job only runs tests and does not require any write access to the repository or other resources, we can set the permissions to `contents: read`, which is generally the minimal sensible setting. This change should be made by adding a `permissions` block under the `test-lib` job, at the same level as `runs-on`. No further code or configuration changes are required, and existing functionality will be preserved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
