### PR TITLE
fix(trusted-types): guard isHTML to avoid Firefox/Safari crash

### DIFF
--- a/projects/ngx-editor/src/lib/trustedTypesUtil.ts
+++ b/projects/ngx-editor/src/lib/trustedTypesUtil.ts
@@ -10,7 +10,8 @@ export const getTrustedTypes = (): TrustedTypePolicyFactory | undefined => {
 };
 
 export const isTrustedHtml = (value: unknown): boolean => {
-  return getTrustedTypes()?.isHTML(value) ?? false;
+  const tt = getTrustedTypes();
+  return !!(tt && typeof tt.isHTML === 'function' && tt.isHTML(value));
 };
 
 export const isHtml = (value: unknown): boolean => {


### PR DESCRIPTION
Problem
Some browsers (Firefox/Safari) expose window.trustedTypes without isHTML, so calling getTrustedTypes().isHTML(value) throws: TypeError: isHTML is not a function

This PR contains:

- [X] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [X] no

### Checklist

- [X] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

Replace the unsafe call to `getTrustedTypes().isHTML(value)` with a guarded check.

- File: `projects/ngx-editor/src/lib/trustedTypesUtil.ts`
- Change: 

  export const isTrustedHtml = (value: unknown): boolean => {
    const tt = getTrustedTypes();
    return !!(tt && typeof tt.isHTML === 'function' && tt.isHTML(value));
  };

Rationale: Firefox/Safari can expose window.trustedTypes without isHTML, causing
TypeError: isHTML is not a function. Guarding the call avoids the crash.

Impact: No public API changes. Chrome behavior unchanged; Firefox/Safari no longer crash.
Notes: No generated bundles committed.

### Does this PR affects any existing issues?
Fixes #616

