### PR TITLE
chore: fork as @feature23/ngx-editor v19.0.0

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -44,6 +44,7 @@ jobs:
       - run: npm ci
       - run: npm run build:lib
 
-      - run: npm publish dist/ngx-editor/ --provenance
+      # FEATURE23-FORK: --access public required for scoped package
+      - run: npm publish dist/ngx-editor/ --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@ All notable changes to this project will be documented in this file.
 > - Documentation
 > - Internal
 
-## 19.0.0-beta.1 (2025-04-26)
+<!-- FEATURE23-FORK: v19.0.0 release entry -->
+
+## 19.0.0 (2026-03-04)
 
 #### Breaking Changes
 
 - requires angular v19 or greater ([ec8f932](https://github.com/sibiraj-s/ngx-editor/commit/ec8f932))
+
+#### Bug Fixes
+
+- add required locale for link component ([#628](https://github.com/sibiraj-s/ngx-editor/pull/628))
+- guard isHTML to avoid Firefox/Safari crash ([#631](https://github.com/sibiraj-s/ngx-editor/pull/631))
+- adds tel URL validation to the toolbar link ([#623](https://github.com/sibiraj-s/ngx-editor/pull/623))
 
 ## 18.0.0 (2024-09-01)
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,15 @@
-# NgxEditor
+<!-- FEATURE23-FORK: README rewritten for fork -->
+
+# @feature23/ngx-editor
+
+> **This is a fork of [ngx-editor](https://github.com/sibiraj-s/ngx-editor) maintained by [feature23](https://github.com/feature23).** It includes experimental changes and Angular version updates that have not yet been merged upstream. If you don't need these changes, please use the official package at [ngx-editor](https://github.com/sibiraj-s/ngx-editor).
 
 <p align="center">
-  <a href="https://github.com/sibiraj-s/ngx-editor">
+  <a href="https://github.com/feature23/ngx-editor">
    <img src="./sketch/ngx-editor.svg" alt="ngxEditor">
   </a>
 </p>
 <p align="center">The Rich Text Editor for Angular, Built on ProseMirror</p>
-<p align="center">
-  <a href="https://github.com/sibiraj-s/ngx-editor/actions">
-    <img alt="Tests" src="https://github.com/sibiraj-s/ngx-editor/workflows/Tests/badge.svg">
-  </a>
-  <a href="https://www.npmjs.com/package/ngx-editor">
-    <img alt="npm version" src="https://badgen.net/npm/v/ngx-editor">
-  </a>
-  <a href="https://www.npmjs.com/package/ngx-editor">
-    <img alt="npm" src="https://badgen.net/npm/dm/ngx-editor">
-  </a>
-  <a href="https://www.npmjs.com/package/ngx-editor">
-    <img alt="npm" src="https://badgen.net/npm/dt/ngx-editor">
-  </a>
-  <br />
-  <a href="https://github.com/sibiraj-s/ngx-editor/blob/master/LICENSE">
-    <img alt="licence" src="https://badgen.net/npm/license/ngx-editor">
-  </a>
-</p>
 
 > A simple rich text editor for angular applications built with ProseMirror. It is a drop in and easy-to-use editor
 > and can be easily extended using prosemirror plugins to build any additional or missing features
@@ -37,11 +23,11 @@
 Install via Package managers such as [npm] or [pnpm] or [yarn]
 
 ```bash
-npm install ngx-editor
+npm install @feature23/ngx-editor
 # or
-pnpm install ngx-editor
+pnpm install @feature23/ngx-editor
 # or
-yarn add ngx-editor
+yarn add @feature23/ngx-editor
 ```
 
 ### Usage
@@ -51,7 +37,11 @@ yarn add ngx-editor
 Component
 
 ```ts
-import { NgxEditorComponent, NgxEditorMenuComponent, Editor } from 'ngx-editor';
+import {
+  NgxEditorComponent,
+  NgxEditorMenuComponent,
+  Editor,
+} from '@feature23/ngx-editor';
 import { FormsModule } from '@angular/forms';
 
 @Component({

--- a/projects/ngx-editor/package.json
+++ b/projects/ngx-editor/package.json
@@ -1,12 +1,13 @@
 {
+  "FEATURE23-FORK": "version, repository, bugs, homepage modified; name renamed to @feature23/ngx-editor at build time via scripts/postbuild.js",
   "name": "ngx-editor",
-  "version": "19.0.0-beta.1",
+  "version": "19.0.0",
   "description": "The Rich Text Editor for Angular, Built on ProseMirror",
   "license": "MIT",
   "type": "module",
-  "repository": "https://github.com/sibiraj-s/ngx-editor.git",
-  "bugs": "https://github.com/sibiraj-s/ngx-editor/issues",
-  "homepage": "https://github.com/sibiraj-s/ngx-editor",
+  "repository": "https://github.com/feature23/ngx-editor.git",
+  "bugs": "https://github.com/feature23/ngx-editor/issues",
+  "homepage": "https://github.com/feature23/ngx-editor",
   "keywords": [
     "angular-editor",
     "angular-wysiwyg-editor",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -17,3 +17,16 @@ const copyFile = async function (srcFilePath, destFilePath) {
 copyFile('README.md', 'README.md');
 copyFile('CHANGELOG.md', 'CHANGELOG.md');
 copyFile('LICENSE', 'LICENSE');
+
+// FEATURE23-FORK: Rename the package for publishing under the @feature23 scope.
+// The source package.json uses "ngx-editor" so that ng-packagr resolves
+// secondary entry points (ngx-editor/utils, ngx-editor/schema, etc.) correctly.
+const distPkgPath = path.resolve(process.cwd(), 'dist/ngx-editor/package.json');
+try {
+  const pkg = JSON.parse(await fs.readFile(distPkgPath, 'utf-8'));
+  pkg.name = '@feature23/ngx-editor';
+  await fs.writeFile(distPkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(pc.green('- Package renamed to @feature23/ngx-editor'));
+} catch (err) {
+  console.log(pc.red('Error renaming package'), err);
+}


### PR DESCRIPTION
Rename published package to @feature23/ngx-editor via postbuild script so internal imports stay as ngx-editor/* for upstream merge-ability. Update version to 19.0.0, repo URLs to feature23/ngx-editor, add --access public to npm publish, update README with fork notice, and add CHANGELOG entry with bug fixes since beta.

All modified locations are tagged with FEATURE23-FORK for easy discovery.

<!-- make sure your title is clear -->
<!-- to mark a task, use [x]. -->
<!-- try not to make breaking changes without discussion first -->
<!-- don't remove this template. else PR might be closed without any discussion -->

This PR contains:

- [ ] bugfix
- [ ] feature
- [ ] refactor
- [ ] tests
- [ ] documentation
- [ ] others

### Breaking Changes?

- [ ] yes
- [ ] no

<!-- If yes, please describe the breakage. -->

### Checklist

- [ ] commit messages follow the [Conventional Commits](https://conventionalcommits.org/) pattern
  - A feature commit message is prefixed "feat:"
  - A bugfix commit message is prefixed "fix:"
  - A document related commit is prefixed "docs:"
- [ ] docs have been added / updated (for bug fixes / features)

### Describe Your Changes

<!--
  please be thorough and clearly explain the problem being solved.
-->

### Does this PR affects any existing issues?

- [ ] yes
- [ ] no

<!--
  if yes mention the issue number and what kind of change it is
  for example: closes #1, fixes #1.
-->
